### PR TITLE
Fix to frame delay management induced by audio

### DIFF
--- a/src/drivers/dingux-sdl/dingoo-sound.cpp
+++ b/src/drivers/dingux-sdl/dingoo-sound.cpp
@@ -22,7 +22,7 @@
 /// \brief Handles sound emulation using the SDL.
 
 #include <stdio.h>
-#include <string.h> 
+#include <string.h>
 #include <stdlib.h>
 
 #include "dingoo.h"
@@ -67,14 +67,14 @@ static void fillaudio(void *udata, uint8 *stream, int len) // len == spec.sample
 
         *tmps = sample;
         tmps++;
-        len--; 
+        len--;
     }
 }
 
 /**
  * Initialize the audio subsystem.
  */
-int InitSound() 
+int InitSound()
 {
     int sound, soundrate, soundbufsize, soundvolume, soundtrianglevolume,
             soundsquare1volume, soundsquare2volume, soundnoisevolume,
@@ -94,7 +94,7 @@ int InitSound()
     }
     char driverName[8];
     SDL_AudioDriverName(driverName, 8);
-    
+
     fprintf(stderr, "Loading SDL sound with %s driver...\n", driverName);
 
     // load configuration variables
@@ -179,7 +179,7 @@ uint32 GetBufferedSound(void) {
 /**
  * Send a sound clip to the audio subsystem.
  */
-void WriteSound(int32 *buf, int Count) 
+void WriteSound(int32 *buf, int Count)
 {
     //extern int EmulationPaused;
     // if(ispressed(DINGOO_L)) {
@@ -196,19 +196,14 @@ void WriteSound(int32 *buf, int Count)
             s_Buffer[s_BufferWrite] = *buf;
             Count--;
             s_BufferWrite = (s_BufferWrite + 1) % s_BufferSize;
-            
+
             s_BufferIn++;
-            
+
             buf++;
         }
     }
 _exit:
     SDL_UnlockAudio();
-
-    // If we have too much audio, wait a bit before accepting more.
-    // This keeps the lag in check.
-    while (GetBufferedSound() > 3 * GetBufferSize())
-        usleep(1000);
 }
 
 /**
@@ -218,7 +213,7 @@ void SilenceSound(int n)
 {
     // Not needed, the callback will write silence to buffer anyway
     // otherwise it causes noticable lag
-    SDL_PauseAudio(n);  
+    SDL_PauseAudio(n);
 }
 
 /**

--- a/src/drivers/dingux-sdl/dingoo-throttle.cpp
+++ b/src/drivers/dingux-sdl/dingoo-throttle.cpp
@@ -58,10 +58,11 @@ void delay_us(uint64 us_count)
 void RefreshThrottleFPS()
 {
     uint64 fps = FCEUI_GetDesiredFPS(); // Do >> 24 to get in Hz
-    desired_frametime = 16777216.0l / (fps * g_fpsScale);
+    //desired_frametime = 16777216.0l / (fps * g_fpsScale);
+    desired_frametime = 20132659.0l / (fps * g_fpsScale);
     desired_frametime_us = (uint64)(desired_frametime * 1000000.0l);
 
-    Lasttime=0;   
+    Lasttime=0;
     Nexttime=0;
     InFrame=0;
     printf("desired_frametime: %i\n", desired_frametime_us);
@@ -80,30 +81,30 @@ int SpeedThrottle()
     }
     uint64 time_left;
     uint64 cur_time;
-    
+
     if(!Lasttime) Lasttime = get_ticks_us();
-    
+
     if(!InFrame) {
         InFrame = 1;
         Nexttime = Lasttime + desired_frametime_us;
     }
-    
+
     cur_time  = get_ticks_us();
 
     if(cur_time >= Nexttime)
         time_left = 0;
     else
         time_left = Nexttime - cur_time;
-    
+
     if(time_left > 50000) {
         time_left = 50000;
         /* In order to keep input responsive, don't wait too long at once */
         /* 50 ms wait gives us a 20 Hz responsetime which is nice. */
     } else InFrame = 0;
-    
+
     //printf("attempting to sleep %Ld ms, frame complete=%i\n", time_left, InFrame);
     delay_us(time_left);
-    
+
     if(!InFrame)
     {
         Lasttime = get_ticks_us();
@@ -119,11 +120,11 @@ void IncreaseEmulationSpeed(void)
 {
 puts("IncreaseEmulationSpeed");
     g_fpsScale *= LOGMUL;
-    
+
     if(g_fpsScale > Fastest) g_fpsScale = Fastest;
 
     RefreshThrottleFPS();
-     
+
     FCEU_DispMessage("emulation speed %.1f%%", g_fpsScale*100.0);
 }
 
@@ -150,7 +151,7 @@ FCEUD_SetEmulationSpeed(int cmd)
 {
 puts("SetEmulationSpeed");
     MaxSpeed = false;
-    
+
     switch(cmd) {
     case EMUSPEED_SLOWEST:
         g_fpsScale = Slowest;

--- a/src/drivers/dingux-sdl/dingoo-video.cpp
+++ b/src/drivers/dingux-sdl/dingoo-video.cpp
@@ -317,9 +317,9 @@ void flip_NNOptimized_AllowOutOfScreen(SDL_Surface *src_surface, SDL_Surface *ds
 			continue;
 		}
 
-		uint16_t *t = (uint16_t *) (dst_surface->pixels + ((i + y_padding) * ((w2 > RES_HW_SCREEN_HORIZONTAL) ? RES_HW_SCREEN_HORIZONTAL : w2)) * sizeof (uint16_t));
+		uint16_t *t = static_cast<uint16_t*>(dst_surface->pixels) + ((i + y_padding) * ((w2 > RES_HW_SCREEN_HORIZONTAL) ? RES_HW_SCREEN_HORIZONTAL : w2));
 		y2 = (i * y_ratio) >> 16;
-		uint16_t *p = (uint16_t *) (src_surface->pixels + (y2 * w1 + x_padding_ratio) * sizeof (uint16_t));
+		uint16_t *p = static_cast<uint16_t*>(src_surface->pixels) + (y2 * w1 + x_padding_ratio);
 		int rat = 0;
 		for (int j = 0; j < w2; j++) {
 			if (j >= RES_HW_SCREEN_HORIZONTAL) {
@@ -357,7 +357,7 @@ void flip_NNOptimized_AllowOutOfScreen_NES(uint8_t *nes_px, SDL_Surface *dst_sur
 			continue;
 		}
 
-		uint16_t *t = (uint16_t *) (dst_surface->pixels + ((i + y_padding) * ((w2 > RES_HW_SCREEN_HORIZONTAL) ? RES_HW_SCREEN_HORIZONTAL : w2)) * sizeof (uint16_t));
+		uint16_t *t = static_cast<uint16_t*>(dst_surface->pixels) + ((i + y_padding) * ((w2 > RES_HW_SCREEN_HORIZONTAL) ? RES_HW_SCREEN_HORIZONTAL : w2));
 		y2 = (i * y_ratio) >> 16;
 		uint8_t *p = (uint8_t *) (nes_px + (y2 * w1 + x_padding_ratio) * sizeof (uint8_t));
 		int rat = 0;
@@ -408,7 +408,7 @@ void flip_Downscale_LeftRightGaussianFilter_NES(uint8_t *nes_px, SDL_Surface *ds
 			continue;
 		}
 
-		uint16_t *t = (uint16_t *) (dst_surface->pixels + ((i + y_padding) * ((w2 > RES_HW_SCREEN_HORIZONTAL) ? RES_HW_SCREEN_HORIZONTAL : w2)) * sizeof (uint16_t));
+		uint16_t *t = static_cast<uint16_t*>(dst_surface->pixels) + ((i + y_padding) * ((w2 > RES_HW_SCREEN_HORIZONTAL) ? RES_HW_SCREEN_HORIZONTAL : w2));
 		y1 = (i * y_ratio) >> 16;
 		uint8_t *p = (uint8_t *) (nes_px + (y1 * w1 + x_padding_ratio) * sizeof (uint8_t));
 		int rat = 0;

--- a/src/drivers/dingux-sdl/dingoo.cpp
+++ b/src/drivers/dingux-sdl/dingoo.cpp
@@ -325,44 +325,26 @@ void quick_save_and_poweroff()
 }
 
 static void DoFun(int fskip) {
-	uint8 *gfx;
-	int32 *sound;
-	int32 ssize;
-	extern uint8 PAL;
-	int done = 0, timer = 0, ticks = 0, tick = 0, fps = 0;
-	unsigned int frame_limit = 60, frametime = 16667;
+  uint8 *gfx;
+  int32 *sound;
+  int32 ssize;
+  extern uint8 PAL;
+  int done = 0, timer = 0, ticks = 0, tick = 0, fps = 0;
+  unsigned int frame_limit = 60, frametime = 16667;
 
-	while (GameInfo) {
-		/* Frameskip decision based on the audio buffer */
-		if (!fpsthrottle) {
-			// Fill up the audio buffer with up to 6 frames dropped.
-			int FramesSkipped = 0;
-			while (GameInfo
-			    && GetBufferedSound() < GetBufferSize() * 3 / 2
-			    && ++FramesSkipped < 6) {
-				FCEUI_Emulate(&gfx, &sound, &ssize, 1);
-				FCEUD_Update(NULL, sound, ssize);
-			}
+  fpsthrottle = false;
 
-			// Force at least one frame to be displayed.
-			if (GameInfo) {
-				FCEUI_Emulate(&gfx, &sound, &ssize, 0);
-				FCEUD_Update(gfx, sound, ssize);
-			}
+  while (GameInfo) {
+    int ticks = SDL_GetTicks();
 
-			// Then render all frames while audio is sufficient.
-			while (GameInfo
-			    && GetBufferedSound() > GetBufferSize() * 3 / 2) {
-				FCEUI_Emulate(&gfx, &sound, &ssize, 0);
-				FCEUD_Update(gfx, sound, ssize);
-			}
-		}
-		else {
-			FCEUI_Emulate(&gfx, &sound, &ssize, 0);
-			FCEUD_Update(gfx, sound, ssize);
-		}
-	}
+    FCEUI_Emulate(&gfx, &sound, &ssize, 0);
+    FCEUD_Update(gfx, sound, ssize);
 
+    int msec = SDL_GetTicks() - ticks;
+
+    if (msec < 16)
+      SDL_Delay(16 - msec);
+  }
 }
 
 /**

--- a/src/drivers/dingux-sdl/dingoo.cpp
+++ b/src/drivers/dingux-sdl/dingoo.cpp
@@ -49,6 +49,9 @@
 #include <windows.h>
 #endif
 
+#include <chrono>
+#include <thread>
+
 extern double g_fpsScale;
 
 extern bool MaxSpeed;
@@ -330,20 +333,27 @@ static void DoFun(int fskip) {
   int32 ssize;
   extern uint8 PAL;
   int done = 0, timer = 0, ticks = 0, tick = 0, fps = 0;
-  unsigned int frame_limit = 60, frametime = 16667;
+  unsigned int frame_limit = 60;
 
-  fpsthrottle = false;
+  namespace sc = std::chrono;
+  using time_stamp = sc::time_point<sc::steady_clock, sc::microseconds>;
+
+  static constexpr auto frametime = sc::microseconds((uint64_t)(1000000 / 60.0f));
 
   while (GameInfo) {
-    int ticks = SDL_GetTicks();
+    time_stamp s = sc::time_point_cast<sc::microseconds>(sc::steady_clock::now());
 
     FCEUI_Emulate(&gfx, &sound, &ssize, 0);
     FCEUD_Update(gfx, sound, ssize);
 
-    int msec = SDL_GetTicks() - ticks;
+    time_stamp e = sc::time_point_cast<sc::microseconds>(sc::steady_clock::now());
 
-    if (msec < 16)
-      SDL_Delay(16 - msec);
+    auto delta = e - s;
+
+    //printf("%d %d %d\n", delta.count(), (frametime - delta).count(), frametime.count());
+
+    if (delta < frametime)
+      std::this_thread::sleep_for(frametime - delta);
   }
 }
 


### PR DESCRIPTION
The current FCEUX version used audio buffer to manage throttling between frames. This caused random and inconsistent frame delay behavior.

This has been fixed with a more traditional approach in which each frame is emulated and proper timing is managed by` std::chrono` functions and `std::this_tread::sleep_for`.

This pull request has been cherry picked, it's a subset of the changes I made to my master branch to compile on my environment so proper testing is required.